### PR TITLE
Refactor/291 게시물 좋아요 수, 댓글 수 조회 로직 리팩토링

### DIFF
--- a/src/main/java/rabbit/umc/com/demo/community/domain/Article.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/Article.java
@@ -69,6 +69,9 @@ public class Article extends BaseTimeEntity {
     @ColumnDefault("0")
     private int likeCount;
 
+    @ColumnDefault("0")
+    private int commentCount;
+
     public void setInactive(){
         this.status = Status.INACTIVE;
     }

--- a/src/main/java/rabbit/umc/com/demo/community/domain/Article.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/Article.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 import rabbit.umc.com.demo.base.BaseTimeEntity;
 import rabbit.umc.com.demo.base.Status;
 
@@ -64,6 +65,9 @@ public class Article extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'ACTIVE'")
     private Status status;
+
+    @ColumnDefault("0")
+    private int likeCount;
 
     public void setInactive(){
         this.status = Status.INACTIVE;

--- a/src/main/java/rabbit/umc/com/demo/community/domain/Comment.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/Comment.java
@@ -45,8 +45,13 @@ public class Comment extends BaseTimeEntity {
     //비즈니스 로직
 
     @PostPersist
-    public void updateCommentCount(){
+    public void updateCommentCountUp(){
         this.article.setCommentCount(article.getCommentCount()+1);
+    }
+
+    @PreRemove
+    public void updateCommentCountDown(){
+        this.article.setCommentCount(article.getCommentCount()-1);
     }
 
     public void lockComment(){

--- a/src/main/java/rabbit/umc/com/demo/community/domain/Comment.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/Comment.java
@@ -43,6 +43,12 @@ public class Comment extends BaseTimeEntity {
     private Status status;
 
     //비즈니스 로직
+
+    @PostPersist
+    public void updateCommentCount(){
+        this.article.setCommentCount(article.getCommentCount()+1);
+    }
+
     public void lockComment(){
         this.status = Status.INACTIVE;
     }

--- a/src/main/java/rabbit/umc/com/demo/community/domain/mapping/LikeArticle.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/mapping/LikeArticle.java
@@ -35,6 +35,11 @@ public class LikeArticle extends BaseTimeEntity {
     private Status status;
 
 
+    @PostPersist
+    public void updateLikeCount(){
+        article.setLikeCount(article.getLikeCount() + 1);
+    }
+
     //Setter
     public void setLikeArticle(User user, Article article){
         this.user = user;

--- a/src/main/java/rabbit/umc/com/demo/community/domain/mapping/LikeArticle.java
+++ b/src/main/java/rabbit/umc/com/demo/community/domain/mapping/LikeArticle.java
@@ -36,8 +36,12 @@ public class LikeArticle extends BaseTimeEntity {
 
 
     @PostPersist
-    public void updateLikeCount(){
+    public void updateLikeCountUp(){
         article.setLikeCount(article.getLikeCount() + 1);
+    }
+    @PreRemove
+    public void updateLikeCountDown(){
+        article.setLikeCount(article.getLikeCount() - 1);
     }
 
     //Setter

--- a/src/main/java/rabbit/umc/com/demo/converter/ArticleConverter.java
+++ b/src/main/java/rabbit/umc/com/demo/converter/ArticleConverter.java
@@ -32,7 +32,7 @@ public class ArticleConverter {
                         .articleId(article.getId())
                         .articleTitle(article.getTitle())
                         .uploadTime(article.getCreatedAt().format(DATE_TIME_FORMATTER))
-                        .likeCount(article.getLikeArticles().size())
+                        .likeCount(article.getLikeCount())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -53,7 +53,7 @@ public class ArticleConverter {
                         .articleId(article.getId())
                         .articleTitle(article.getTitle())
                         .uploadTime(article.getCreatedAt().format(DATE_TIME_FORMATTER))
-                        .likeCount(article.getLikeArticles().size())
+                        .likeCount(article.getLikeCount())
                         .build())
                 .collect(Collectors.toList());
 
@@ -66,8 +66,8 @@ public class ArticleConverter {
                         .articleId(article.getId())
                         .articleTitle(article.getTitle())
                         .uploadTime(DateUtil.makeArticleUploadTime(article.getCreatedAt()))
-                        .likeCount(article.getLikeArticles().size())
-                        .commentCount(article.getComments().size())
+                        .likeCount(article.getLikeCount())
+                        .commentCount(article.getCommentCount())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -79,8 +79,8 @@ public class ArticleConverter {
                         .articleId(article.getId())
                         .articleTitle(article.getTitle())
                         .uploadTime(article.getCreatedAt().format(DATE_TIME_FORMATTER))
-                        .likeCount(article.getLikeArticles().size())
-                        .commentCount(article.getComments().size())
+                        .likeCount(article.getLikeCount())
+                        .commentCount(article.getCommentCount())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -114,8 +114,8 @@ public class ArticleConverter {
                 .likeArticle(isLike)
                 .articleImage(articleImages)
                 .commentList(commentLists)
-                .likeCount(article.getLikeArticles().size())
-                .commentCount(article.getComments().size())
+                .likeCount(article.getLikeCount())
+                .commentCount(article.getLikeCount())
                 .build();
     }
 


### PR DESCRIPTION
이슈 : 게시물 좋아요 수, 댓글 수 조회 로직 리팩토링
이슈 번호 : #291 

기존 : 객체 그래프 탐색을 통해 게시물에 대한 좋아요 수, 댓글 수를 size()를 이용해 가져오던 로직
리팩토링 : 게시물 컬럼에 각각 카운팅하는 컬럼을 생성하고 JPA Auditing을 이용하여 각각 객체가 생성, 삭제될 때 개수 업데이트 